### PR TITLE
节点中CDATA修正

### DIFF
--- a/lib/xml2json.js
+++ b/lib/xml2json.js
@@ -50,6 +50,7 @@
 exports.parser = function(xmlcode,ignoretags,debug){
 		if(!ignoretags){ignoretags=""};
 		xmlcode=xmlcode.replace(/\s*\/>/g,'/>');
+		xmlcode=xmlcode.replace(/<\?[^>]*>/g,"").replace(/<!\[CDATA\[(.*?)\]\]>/g,"$1");
 		xmlcode=xmlcode.replace(/<\?[^>]*>/g,"").replace(/<\![^>]*>/g,"");
 		if (!ignoretags.sort){ignoretags=ignoretags.split(",")};
 		var x=this.no_fast_endings(xmlcode);


### PR DESCRIPTION
如果节点中存在<![CDATA[ 风景名胜;公园广场;城市广场 ]]>，则中间有效字符会被替换为空，已修正
